### PR TITLE
build: Add support for changing D-Bus server name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,9 +205,14 @@ AM_CONDITIONAL([BUILD_SERVER], [test "x$enable_lib_only" = "xno"])
 AC_DEFINE([DLEYNA_SERVER_OBJECT], "/com/intel/dLeynaServer", [Name of object exposed by dleyna-server])
 AC_DEFINE([DLEYNA_SERVER_PATH], "/com/intel/dLeynaServer/server", [Path of server objects])
 
-DLEYNA_SERVER_NAME=com.intel.dleyna-server
+AC_ARG_WITH(dleyna-service-name,
+		AS_HELP_STRING(
+			[--with-dleyna-service-name],
+			[Specify a D-Bus service name to own]),
+		[with_dleyna_service_name="$withval"], [with_dleyna_service_name="com.intel.dleyna-server"])
+DLEYNA_SERVER_NAME=$with_dleyna_service_name
 AC_SUBST(DLEYNA_SERVER_NAME)
-AC_DEFINE([DLEYNA_SERVER_NAME], "com.intel.dleyna-server",
+AC_DEFINE_UNQUOTED([DLEYNA_SERVER_NAME], ["$with_dleyna_service_name"],
 				 [d-Bus Name of dleyna-server])
 
 DLEYNA_SERVER_INTERFACE_MANAGER=com.intel.dLeynaServer.Manager

--- a/server/Makefile.am
+++ b/server/Makefile.am
@@ -15,11 +15,11 @@ dleyna_server_service_LDADD =	$(GLIB_LIBS)				    			\
 
 dbusservicedir = $(DBUS_SERVICE_DIR)
 dbusservice_in_files = com.intel.dleyna-server.service.in
-dbusservice_DATA = com.intel.dleyna-server.service
+dbusservice_DATA = $(DLEYNA_SERVER_NAME).service
 
-# Replace the 'libexecdir' marker with its fully expanded value
-%.service: %.service.in Makefile
-	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(libexecdir)|" $< > $@
+# Replace the 'libexecdir' marker and DLEYNA_SERVER_NAME with their fully expanded value
+$(DLEYNA_SERVER_NAME).service: com.intel.dleyna-server.service.in Makefile
+	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(libexecdir)|" -e "s|\@DLEYNA_SERVER_NAME\@|$(DLEYNA_SERVER_NAME)|" $< > $@
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = dleyna-server-service-1.0.pc

--- a/server/com.intel.dleyna-server.service.in
+++ b/server/com.intel.dleyna-server.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
-Name=com.intel.dleyna-server
+Name=@DLEYNA_SERVER_NAME@
 Exec=@libexecdir@/dleyna-server-service
 


### PR DESCRIPTION
Allow changing the D-Bus server name so that it can be owned when within
a sandbox such as a Flatpak. That would allow launching the dleyna
services within the sandbox, without needing this service on the host.

For example:
./configure --with-dleyna-service-name=org.gnome.Totem.dleyna-server